### PR TITLE
Removed breathalyzer and drugalyzer animation for suspects on bike

### DIFF
--- a/Traffic Policer/Impairment Tests/Breathalyzer.cs
+++ b/Traffic Policer/Impairment Tests/Breathalyzer.cs
@@ -70,7 +70,10 @@ namespace Traffic_Policer.Impairment_Tests
                                     {
                                         //Game.LocalPlayer.Character.Tasks.PlayAnimation("missfbi3_party_b", "walk_to_balcony_male2", 0.5f, AnimationFlags.None).WaitForCompletion(500);
                                         Game.LocalPlayer.Character.Tasks.PlayAnimation("amb@code_human_police_investigate@idle_b", "idle_e", 2f, 0);
-                                        nearestPed.Tasks.PlayAnimation("amb@incar@male@smoking_low@idle_a", "idle_a", 2f, 0);
+                                        if(!nearestPed.CurrentVehicle.IsBike)
+                                        {
+                                            nearestPed.Tasks.PlayAnimation("amb@incar@male@smoking_low@idle_a", "idle_a", 2f, 0);
+                                        }
                                         GameFiber.Sleep(2000);
                                     }
                                     else

--- a/Traffic Policer/Impairment Tests/DrugTestKit.cs
+++ b/Traffic Policer/Impairment Tests/DrugTestKit.cs
@@ -12,7 +12,7 @@ namespace Traffic_Policer.Impairment_Tests
     internal enum DrugsLevels { POSITIVE, NEGATIVE };
     internal static class DrugTestKit
     {
-        
+
         private static Dictionary<PoolHandle, DrugsLevels> pedCannabisLevels = new Dictionary<PoolHandle, DrugsLevels>();
         private static Dictionary<PoolHandle, DrugsLevels> pedCocaineLevels = new Dictionary<PoolHandle, DrugsLevels>();
         internal static void testNearestPedForDrugs()
@@ -59,7 +59,10 @@ namespace Traffic_Policer.Impairment_Tests
                                     {
                                         //Game.LocalPlayer.Character.Tasks.PlayAnimation("missfbi3_party_b", "walk_to_balcony_male2", 0.5f, AnimationFlags.None).WaitForCompletion(500);
                                         Game.LocalPlayer.Character.Tasks.PlayAnimation("amb@code_human_police_investigate@idle_b", "idle_e", 2f, 0);
-                                        nearestPed.Tasks.PlayAnimation("amb@incar@male@smoking_low@idle_a", "idle_a", 2f, 0);
+                                        if (!nearestPed.CurrentVehicle.IsBike)
+                                        {
+                                            nearestPed.Tasks.PlayAnimation("amb@incar@male@smoking_low@idle_a", "idle_a", 2f, 0);
+                                        }
                                         GameFiber.Sleep(2000);
                                     }
                                     else
@@ -197,10 +200,10 @@ namespace Traffic_Policer.Impairment_Tests
                 {
                     pedCocaineLevels[ped.Handle] = cocaineLevel;
                 }
-                
-                
+
+
             }
-            
+
         }
         public static void SetPedDrugsLevels(Ped ped, bool Cannabis, bool Cocaine)
         {


### PR DESCRIPTION
If you've ever noticed while breathalyzing a suspect on a bike, the "amb@incar@male@smoking_low@idle_a" animation looks weird as it makes the suspect lie down on their bike. I think this animation is supposed to work only for people in cars. Adding a check for bike helps get rid of this animation for suspects on bikes. However, I was thinking if we could use an alternative animation for this purpose. 
Is there a way to look at all the animations in GTA-5 and use one of them? While I was able to find a list of animations at https://alexguirre.github.io/animations-list/. I'm not sure how to see what each of them does. Is there a better way other than trying some probable animations in the game one by one?
@Albo1125 @LSPDFR-PeterU 